### PR TITLE
fix index range

### DIFF
--- a/fusion.py
+++ b/fusion.py
@@ -83,7 +83,7 @@ class TSDFVolume:
           int vol_dim_x = (int) vol_dim[0];
           int vol_dim_y = (int) vol_dim[1];
           int vol_dim_z = (int) vol_dim[2];
-          if (voxel_idx > vol_dim_x*vol_dim_y*vol_dim_z)
+          if (voxel_idx >= vol_dim_x*vol_dim_y*vol_dim_z)
               return;
           // Get voxel grid coordinates (note: be careful when casting)
           float voxel_x = floorf(((float)voxel_idx)/((float)(vol_dim_y*vol_dim_z)));


### PR DESCRIPTION
Since it is 0-base, the illegal voxel_idx should be in [0, vol_dim_x*vol_dim_y*vol_dim_z). This bug may lead to "illegal memory access"