### PR TITLE
Fixing problem with double mc surface.

### DIFF
--- a/fusion.py
+++ b/fusion.py
@@ -118,7 +118,7 @@ class TSDFVolume:
           float depth_diff = depth_value-cam_pt_z;
           if (depth_diff < -trunc_margin)
               return;
-          float dist = fmin(1.0f,depth_diff/trunc_margin);
+          float dist = -fmin(1.0f,depth_diff/trunc_margin);
           float w_old = weight_vol[voxel_idx];
           float obs_weight = other_params[5];
           float w_new = w_old + obs_weight;


### PR DESCRIPTION
Currently, If view from the ray origin: 
o ------> 1 1 1 1 -0.8 -0.6 -0.4 -0.2 0 0.2 0.4 0.6 0.8 1 1 1 1 1  which generates 2 surfaces when extracting 0 level set, the first surface before the surface, the second surface is the surface we want. After the change:
o ------> 1 1 1 1 0.8 0.6 0.4 0.2 0 -0.2 -0.4 -0.6 -0.8 -1 -1 -1 -1 -1  which will now generates only 1 surface when extracting 0 level set.